### PR TITLE
Support lcm and gflags libraries CMake namespace

### DIFF
--- a/kuka-driver/CMakeLists.txt
+++ b/kuka-driver/CMakeLists.txt
@@ -32,7 +32,7 @@ add_definitions(-std=c++11)
 set(driver_name kuka_driver)
 add_executable(${driver_name} kuka_driver.cc)
 add_dependencies(${driver_name} fri-client)
-target_link_libraries(${driver_name} ${fri_client_library} lcm gflags)
+target_link_libraries(${driver_name} ${fri_client_library} ${LCM_NAMESPACE}lcm ${gflags_LIBRARIES})
 
 # install the lcm driver
 install(TARGETS ${driver_name}


### PR DESCRIPTION
Older versions of lcm-config.cmake and gflags-config.cmake were not
using a namespace for their targets, but newer versions do. Using
the CMake *_LIBRARIES variables instead of directly using the targets
names allows to use both the old and new versions of the cmake
configuration files.