### PR TITLE
Use full lcmtypes_drake_cc instead of narrower dep

### DIFF
--- a/kuka-driver/BUILD.bazel
+++ b/kuka-driver/BUILD.bazel
@@ -12,7 +12,7 @@ cc_binary(
     ],
     deps = [
         "@drake//common:essential",
-        "@drake//lcmtypes:iiwa",
+        "@drake//lcmtypes:lcmtypes_drake_cc",
         "@gflags",
         "@kuka_fri//:kuka-fri-lib",
         "@lcm",


### PR DESCRIPTION
The narrower dep is deprecated.
See https://github.com/RobotLocomotion/drake/pull/23467.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-iiwa-driver/51)
<!-- Reviewable:end -->
